### PR TITLE
Add Pelican static site skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+output/
+__pycache__/
+*.pyc

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+html:
+	pelican content
+
+clean:
+	rm -rf output
+
+serve:
+	cd output && python3 -m http.server

--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-# blog_pelican
+# Blog Pelican
+
+This repository contains a minimal setup for a static site generated with [Pelican](https://getpelican.com/).
+
+## Getting Started
+
+1. Install dependencies (Pelican):
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Generate the site:
+   ```bash
+   pelican content
+   ```
+3. Preview the output by serving the generated `output/` directory with your preferred web server.
+
+The configuration can be found in `pelicanconf.py` and the example article is in `content/welcome.md`.

--- a/content/welcome.md
+++ b/content/welcome.md
@@ -1,0 +1,5 @@
+Title: Welcome
+Date: 2024-01-01
+Category: General
+
+Welcome to my new Pelican site!

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -1,0 +1,11 @@
+AUTHOR = 'Your Name'
+SITENAME = 'My Blog'
+SITEURL = ''
+
+PATH = 'content'
+TIMEZONE = 'UTC'
+DEFAULT_LANG = 'en'
+
+# Output directory
+OUTPUT_PATH = 'output/'
+

--- a/publishconf.py
+++ b/publishconf.py
@@ -1,0 +1,5 @@
+from pelicanconf import *
+
+SITEURL = 'https://example.com'
+RELATIVE_URLS = False
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+pelican


### PR DESCRIPTION
## Summary
- set up simple Pelican configuration and sample content
- document how to generate the site in README
- include Makefile for common tasks
- ignore output folders

## Testing
- `python3 -m py_compile pelicanconf.py publishconf.py`
