### PR TITLE
Prepare Pelican site for Vercel deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,11 @@ This repository contains a minimal setup for a static site generated with [Pelic
 3. Preview the output by serving the generated `output/` directory with your preferred web server.
 
 The configuration can be found in `pelicanconf.py` and the example article is in `content/welcome.md`.
+
+## Deploying to Vercel
+
+1. Add this repository to Vercel.
+2. Vercel will use the `vercel.json` configuration to install dependencies with `pip`, run `pelican content`, and serve the `output/` directory as the static site.
+
+The included `index.md` page provides a simple home page for the site.
+

--- a/content/index.md
+++ b/content/index.md
@@ -1,0 +1,5 @@
+Title: Home
+Date: 2024-01-01
+save_as: index.html
+
+Welcome to my Pelican site hosted on Vercel!

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "buildCommand": "pelican content",
+  "installCommand": "pip install -r requirements.txt",
+  "outputDirectory": "output"
+}


### PR DESCRIPTION
## Summary
- add `vercel.json` with build and install commands
- add a simple index page
- document deploying the site on Vercel

## Testing
- `git status --short`